### PR TITLE
Fix secondary groups so we actually ensure we have the desired number of copies in each group.

### DIFF
--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/Main.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/Main.scala
@@ -317,6 +317,11 @@ object Main {
   def secondariesToAdd(secondaryGroup: SecondaryGroupConfig, currentDatasetSecondaries: Set[String],
                        datasetId: DatasetId, secondaryGroupStr: String): Set[String] = {
 
+    /*
+     * The dataset may be in secondaries defined in other groups, but here we need to reason 
+     * only about secondaries in this group since selection is done group by group.  For example,
+     * if we need two replicas in this group then secondaries outside this group don't count.
+     */
     val currentDatasetSecondariesForGroup = currentDatasetSecondaries.intersect(secondaryGroup.instances)
     val desiredCopies = secondaryGroup.numReplicas
     val newCopiesRequired = Math.max(desiredCopies - currentDatasetSecondariesForGroup.size, 0)

--- a/coordinator/src/test/scala/com/socrata/datacoordinator/service/MainTest.scala
+++ b/coordinator/src/test/scala/com/socrata/datacoordinator/service/MainTest.scala
@@ -1,0 +1,29 @@
+package com.socrata.datacoordinator.service
+
+import com.socrata.datacoordinator.id.DatasetId
+import org.scalatest.{MustMatchers, FunSuite}
+
+class MainTest extends FunSuite with MustMatchers {
+  private val sg1 = SecondaryGroupConfig(2, Set("pg1", "pg2", "pg3"))
+  private val ds = new DatasetId(1234)
+
+  test("do nothing if already have sufficient") {
+    val newSecondaries = Main.secondariesToAdd(sg1, Set("pg1", "pg3"), ds, "g1")
+    newSecondaries must have size 0
+  }
+
+  test("add if not enough in group") {
+    // ensure it has enough from the specific  group, not just any group
+    val newSecondaries = Main.secondariesToAdd(sg1, Set("pg1", "pg4", "pgx"), ds, "g1")
+    newSecondaries must have size 1
+    newSecondaries.intersect(sg1.instances) must have size 1
+  }
+
+  test("add if none in group") {
+    val newSecondaries = Main.secondariesToAdd(sg1, Set(), ds, "g1")
+    newSecondaries must have size 2
+    newSecondaries.intersect(sg1.instances) must have size 2
+  }
+
+
+}


### PR DESCRIPTION
We were only checking to make sure we have the right number of copies total, making secondary groups not
work at all.

I wrote this over a year ago with the exact use case I have now in mind, only we haven't used it yet
and I failed on writing tests because I could barely write Scala so it didn't work.  The test now is
weak, but I didn't want to refactor the whole class right now.

The only intended actual code change is adding "intersect(secondaryGroup.instances)", everything else is
just to get the logic in a place it can be easily tested.