### PR TITLE
effectively unlimited query pool for secondary watcher

### DIFF
--- a/coordinator/docker-secondary-watcher/secondary-watcher.conf.j2
+++ b/coordinator/docker-secondary-watcher/secondary-watcher.conf.j2
@@ -13,6 +13,11 @@ com.socrata.coordinator.secondary-watcher {
   claim-timeout = "30m"
 
   database {
+    # Running out of pooled connections can result in strange and difficult to detect failure conditions.
+    # For example, the claim manager can get blocked resulting in claims not being updated and thus stolen.
+    # We control concurrency by the number of workers combined with the number of secondary instances configured, so
+    # we set it to a "essentially unlimited" value for the secondary watcher.
+    c3p0.maxPoolSize = 10000
     host = "{{ DATA_COORDINATOR_DB_HOST }}"
     port = "{{ DATA_COORDINATOR_DB_PORT }}"
     database = "{{ DATA_COORDINATOR_DB_NAME }}"

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcher.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcher.scala
@@ -164,6 +164,10 @@ class SecondaryWatcherClaimManager(dsInfo: DSInfo, claimantId: UUID, claimTimeou
   }
 
   private def updateDatasetClaimedAtTime() {
+    // TODO: We have a difficult to debug problem here if our connection pool isn't large enough to satisfy
+    // all our workers, since it can block claim updates and result in claims being overwritten.
+    // For now we are working around it by configuring a large pool and relying on worker config to control
+    // concurrency.  We could potentially have a separate pool for the claim manager.
     using(dsInfo.dataSource.getConnection()) { conn =>
       using(conn.prepareStatement(
         """UPDATE secondary_manifest


### PR DESCRIPTION
Running out of pooled connections can result in strange and difficult to detect failure conditions. For example, the claim manager can get blocked resulting in claims not being updated and thus stolen. We control concurrency by the number of workers combined with the number of secondary instances configured, so we set it to a "essentially unlimited" value for the secondary watcher.