### PR TITLE
Cap DC memory usage - limit # mutation threads

### DIFF
--- a/coordinator/src/main/resources/reference.conf
+++ b/coordinator/src/main/resources/reference.conf
@@ -1,5 +1,5 @@
 com.socrata.coordinator.common {
- 
+
   log4j {
     rootLogger = [ INFO, console ]
     appender {
@@ -60,6 +60,10 @@ com.socrata.coordinator.service = ${com.socrata.coordinator.common} {
   log-table-cleanup-delete-older-than = 30 days
   # look at each log table every two weeks
   log-table-cleanup-delete-every = 14 days
+
+  # Max # of ingestion or mutation threads.  Each one uses some memory, so don't allow too many.
+  # Estimate 100MB per thread.
+  max-mutation-threads = 15
 
   reports {
     directory = ${java.io.tmpdir}

--- a/coordinator/src/main/resources/reference.conf
+++ b/coordinator/src/main/resources/reference.conf
@@ -65,6 +65,9 @@ com.socrata.coordinator.service = ${com.socrata.coordinator.common} {
   # Estimate 100MB per thread.
   max-mutation-threads = 15
 
+  # Amount of time to wait for number of mutation threads to fall below max-mutation-threads
+  mutation-resource-timeout = 5 minutes
+
   reports {
     directory = ${java.io.tmpdir}
     index-block-size = 64K

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/ServiceConfig.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/ServiceConfig.scala
@@ -33,6 +33,8 @@ class ServiceConfig(val config: Config, root: String) {
                                      config.getDuration(k("log-table-cleanup-delete-every"), MILLISECONDS),
                                      TimeUnit.MILLISECONDS)
   val maxMutationThreads = config.getInt(k("max-mutation-threads"))
+  val mutationResourceTimeout = new FiniteDuration(config.getDuration(k("mutation-resource-timeout"),
+                                                   MILLISECONDS), TimeUnit.MILLISECONDS)
 
   require(instance.matches("[a-zA-Z0-9._]+"),
           "Instance names must consist of only ASCII letters, numbers, periods, and underscores")

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/ServiceConfig.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/ServiceConfig.scala
@@ -32,6 +32,7 @@ class ServiceConfig(val config: Config, root: String) {
   val logTableCleanupDeleteEvery = new FiniteDuration(
                                      config.getDuration(k("log-table-cleanup-delete-every"), MILLISECONDS),
                                      TimeUnit.MILLISECONDS)
+  val maxMutationThreads = config.getInt(k("max-mutation-threads"))
 
   require(instance.matches("[a-zA-Z0-9._]+"),
           "Instance names must consist of only ASCII letters, numbers, periods, and underscores")

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/loader/sql/AbstractRepBasedDataSqlizer.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/loader/sql/AbstractRepBasedDataSqlizer.scala
@@ -11,6 +11,14 @@ import com.socrata.datacoordinator.id.{ColumnId, RowId}
 import com.socrata.datacoordinator.util.collection.{ColumnIdSet, RowIdSet, MutableRowIdSet}
 import java.io.Closeable
 
+/**
+ * Abstract SQL adapter for data access
+ *
+ * @param softMaxBatchSize in bytes, the max size of each batch to insert.
+ * This is actually very tricky because the size is estimated from the SqlRep's estimatedSize
+ * method for each column value, but doesn't include the intermediate objects produced, which
+ * are actually the most expensive and may take 100x as much memory as the estimated size.
+ */
 abstract class AbstractRepBasedDataSqlizer[CT, CV](val dataTableName: String,
                                                    val datasetContext: RepBasedSqlDatasetContext[CT, CV],
                                                    val softMaxBatchSize: Int = 1000000)

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/loader/sql/AbstractRepBasedDataSqlizer.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/loader/sql/AbstractRepBasedDataSqlizer.scala
@@ -12,7 +12,8 @@ import com.socrata.datacoordinator.util.collection.{ColumnIdSet, RowIdSet, Mutab
 import java.io.Closeable
 
 abstract class AbstractRepBasedDataSqlizer[CT, CV](val dataTableName: String,
-                                                   val datasetContext: RepBasedSqlDatasetContext[CT, CV])
+                                                   val datasetContext: RepBasedSqlDatasetContext[CT, CV],
+                                                   val softMaxBatchSize: Int = 1000000)
   extends DataSqlizer[CT, CV]
 {
   val typeContext = datasetContext.typeContext
@@ -26,8 +27,6 @@ abstract class AbstractRepBasedDataSqlizer[CT, CV](val dataTableName: String,
   val sidRep = repSchema(datasetContext.systemIdColumn).asInstanceOf[SqlPKableColumnRep[CT, CV]]
   val pkRep = repSchema(logicalPKColumnName).asInstanceOf[SqlPKableColumnRep[CT, CV]]
   val versionRep = repSchema(datasetContext.versionColumn)
-
-  def softMaxBatchSize = 2000000
 
   def sizeofDelete(id: CV) = pkRep.estimateSize(id)
 


### PR DESCRIPTION
Each mutation thread can use a significant amount of memory due to batching up mutations before writing to truth.  Cap the number of mutation threads allowed using an AtomicInteger.  Note this number should be smaller than the total number of threads serving requests to allow for exports and other requests.  

Also, reduce the default batch size.